### PR TITLE
Generalize hardware assumptions across playbook

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,7 +21,7 @@ vlans:
   storage:
     id: 10
     subnet: "10.10.10.0/24"
-    mtu: 9000
+    mtu: 9000  # jumbo frames — requires switch + NIC support; set to 1500 for 1GbE or unsupported hardware
     description: "iSCSI replication between storage nodes"
   management:
     id: 20
@@ -31,7 +31,7 @@ vlans:
   client:
     id: 30
     subnet: "10.30.30.0/24"
-    mtu: 9000  # set to 1500 if not all clients support jumbo
+    mtu: 9000  # jumbo frames — set to 1500 if clients or switches don't support them
     description: "NFS, SMB, iSCSI client traffic"
 
 # Floating VIPs — managed by Pacemaker, bind to client VLAN
@@ -55,16 +55,20 @@ corosync_transport: knet
 corosync_crypto_cipher: aes256
 corosync_crypto_hash: sha256
 
-# Node definitions for corosync.conf — ring0 = mgmt, ring1 = storage (optional)
+# Node definitions for corosync.conf.
+# ring0 is always required (management VLAN).
+# ring1 is optional — omit ring1_addr for nodes that share a single NIC across
+# all VLANs, or when you don't want a redundant cluster heartbeat on the
+# storage VLAN. Remove ring1_addr from both storage nodes to disable ring1.
 corosync_nodes:
   - name: storage-a
     nodeid: 1
     ring0_addr: "10.20.20.1"
-    ring1_addr: "10.10.10.1"   # storage VLAN — redundant ring
+    ring1_addr: "10.10.10.1"   # optional: storage VLAN redundant ring — remove if using shared/single NIC
   - name: storage-b
     nodeid: 2
     ring0_addr: "10.20.20.2"
-    ring1_addr: "10.10.10.2"
+    ring1_addr: "10.10.10.2"   # optional: remove if not using a dedicated storage NIC
   - name: quorum
     nodeid: 3
     ring0_addr: "10.20.20.3"

--- a/group_vars/storage_nodes.yml
+++ b/group_vars/storage_nodes.yml
@@ -6,11 +6,45 @@
 # ---------------------------------------------------------------------------
 # Network interfaces — adjust to match your hardware
 # ---------------------------------------------------------------------------
-# These are the physical or bond interface names BEFORE VLAN subinterfaces.
-# The playbook creates VLAN subinterfaces on top of these.
-net_storage_parent: "ens3f0"      # 40GbE Mellanox — for iSCSI replication
-net_client_parent: "ens3f1"       # for NFS/SMB/iSCSI client traffic
-net_mgmt_interface: "eno1"        # 1GbE onboard — management + Corosync ring0
+# Physical or bond interface names used as VLAN parents.
+# NOTE: The playbook does NOT configure OS network interfaces. These variables
+# are informational — override per-host in host_vars/<hostname>.yml when nodes
+# have different NIC models or names.
+#
+# Three common deployment scenarios:
+#
+# A) Dedicated NIC per network (recommended for performance isolation)
+#    Separate physical or bond interfaces for each traffic type.
+#    Corosync ring1 on the storage VLAN provides a redundant heartbeat.
+#
+#      net_mgmt_interface: "eno1"      # Management, SSH, Corosync ring0
+#      net_storage_parent: "ens3f0"    # iSCSI backend replication
+#      net_client_parent:  "ens3f1"    # NFS / SMB / iSCSI client traffic
+#      # in all.yml: include ring1_addr in corosync_nodes for storage nodes
+#
+# B) Shared NIC for storage + client, dedicated management
+#    One high-speed NIC carries both storage and client VLANs.
+#    Set net_storage_parent and net_client_parent to the same interface.
+#    Corosync ring1 can still use the storage VLAN on this NIC, or be omitted.
+#
+#      net_mgmt_interface: "eno1"      # Management
+#      net_storage_parent: "eth0"      # iSCSI backend (storage VLAN)
+#      net_client_parent:  "eth0"      # NFS/SMB/iSCSI client (client VLAN)
+#      # in all.yml: omit ring1_addr from corosync_nodes to skip ring1
+#
+# C) All traffic on one NIC (lab / minimal hardware)
+#    A single interface carries all VLANs. Only ring0 is used for Corosync.
+#
+#      net_mgmt_interface: "eth0"      # All traffic
+#      net_storage_parent: "eth0"
+#      net_client_parent:  "eth0"
+#      # in all.yml: omit ring1_addr from corosync_nodes
+#
+# Default below matches scenario A with placeholder names.
+# Run `ip link show` on your nodes to find actual interface names.
+net_mgmt_interface: "eno1"        # Management — SSH, Corosync ring0
+net_storage_parent: "ens3f0"      # iSCSI backend replication (storage VLAN)
+net_client_parent:  "ens3f1"      # NFS / SMB / iSCSI client traffic (client VLAN)
 
 # ---------------------------------------------------------------------------
 # ZFS
@@ -245,8 +279,18 @@ sanoid_templates:
     autoprune: true
 
 # ---------------------------------------------------------------------------
-# TCP / Network tuning for 40GbE iSCSI
+# TCP / Network performance tuning (optional)
 # ---------------------------------------------------------------------------
+# Increases TCP socket buffer sizes for high-throughput iSCSI.
+# Scale rmem_max/wmem_max to roughly 1/8 of your per-session bandwidth:
+#   1GbE  (~125 MB/s):  4194304   (4 MB)
+#   10GbE (~1.2 GB/s):  8388608   (8 MB)
+#   25GbE (~3 GB/s):    16777216  (16 MB)  ← values below
+#   40GbE+ (~5 GB/s):   33554432  (32 MB)
+#
+# To disable TCP buffer tuning entirely (e.g. kernel defaults are fine),
+# comment out or remove the tcp_tunables block. The hardening role skips
+# this step when tcp_tunables is not defined.
 tcp_tunables:
   net.core.rmem_max: 16777216
   net.core.wmem_max: 16777216

--- a/host_vars/storage-a.yml
+++ b/host_vars/storage-a.yml
@@ -32,7 +32,12 @@ iscsi_peer_iqn: "{{ iscsi_iqn_prefix }}:storage-b"
 #
 # Example output:
 #   ata-WDC_WD100EFAX-68LHPN0_XXXXXXXX -> ../../sda
-#   ata-WDC_WD100EFAX-68LHPN0_YYYYYYYY -> ../../sdb
+#   ata-Samsung_SSD_870_EVO_4TB_XXXXXXX -> ../../sdb
+#
+# Any number of disks is supported — 1, 2, 4, 12, 24, etc.
+# Each entry in local_data_disks on storage-a is mirrored 1:1 with the
+# corresponding entry on storage-b (matched by position). Both nodes must
+# have the same count.
 #
 # Symmetric active/passive HA design:
 # Each node exports its local disks via LIO iSCSI target AND connects to the peer's target.
@@ -50,22 +55,7 @@ local_data_disks:
     label: "data-a-2"
   - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_3
     label: "data-a-3"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_4
-    label: "data-a-4"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_5
-    label: "data-a-5"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_6
-    label: "data-a-6"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_7
-    label: "data-a-7"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_8
-    label: "data-a-8"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_9
-    label: "data-a-9"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_10
-    label: "data-a-10"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_A_11
-    label: "data-a-11"
+  # Add more disks here following the same pattern
 
 # Optional: SLOG and special vdev disks (NVMe recommended for SLOG)
 # SLOG accelerates sync writes (NFS sync, database commits) significantly.

--- a/host_vars/storage-b.yml
+++ b/host_vars/storage-b.yml
@@ -26,6 +26,9 @@ iscsi_peer_iqn: "{{ iscsi_iqn_prefix }}:storage-a"
 #   ls -la /dev/disk/by-id/ | grep -v part | grep -v wwn
 #   Use ata-*, scsi-*, or nvme-* identifiers (NOT wwn — those are hardware-specific)
 #
+# Any number of disks is supported — 1, 2, 4, 12, 24, etc.
+# Must match the count in host_vars/storage-a.yml (mirrored 1:1 by position).
+#
 # Symmetric active/passive HA design:
 # Each node exports its local disks via LIO iSCSI target AND connects to the peer's target.
 # ZFS pool mirrors own local disks (physical) with peer's disks (iSCSI).
@@ -42,22 +45,7 @@ local_data_disks:
     label: "data-b-2"
   - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_3
     label: "data-b-3"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_4
-    label: "data-b-4"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_5
-    label: "data-b-5"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_6
-    label: "data-b-6"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_7
-    label: "data-b-7"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_8
-    label: "data-b-8"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_9
-    label: "data-b-9"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_10
-    label: "data-b-10"
-  - device: /dev/disk/by-id/ata-PLACEHOLDER_DISK_B_11
-    label: "data-b-11"
+  # Add more disks here following the same pattern
 
 # Optional: SLOG and special vdev disks (NVMe recommended for SLOG)
 # SLOG accelerates sync writes (NFS sync, database commits) significantly.

--- a/roles/hardening/tasks/main.yml
+++ b/roles/hardening/tasks/main.yml
@@ -19,12 +19,12 @@
   notify: reload sysctl
 
 # ─── TCP performance tuning (storage nodes only) ──────────────────────────
-- name: Deploy TCP tuning for 40GbE
+- name: Deploy TCP tuning
   ansible.builtin.copy:
     dest: /etc/sysctl.d/91-tcp-tuning.conf
     mode: "0644"
     content: |
-      # Managed by Ansible — 40GbE iSCSI TCP tuning
+      # Managed by Ansible — iSCSI TCP tuning
       {% for key, value in tcp_tunables.items() %}
       {{ key }} = {{ value }}
       {% endfor %}


### PR DESCRIPTION
- Remove 40GbE-specific labeling from TCP tunables; add per-link-speed
  sizing guide (1GbE→4MB, 10GbE→8MB, 25GbE→16MB, 40GbE+→32MB) and
  document how to disable the block entirely

- Expand network interface section in storage_nodes.yml with three
  documented scenarios: dedicated NIC per network, shared NIC for
  storage+client, and single NIC for all traffic; note the playbook
  does not configure interfaces and vars should be overridden per-host
  when nodes have dissimilar hardware

- Document Corosync ring1 as optional in all.yml; clarify that removing
  ring1_addr from corosync_nodes is sufficient to disable it (the
  corosync.conf template already handles the optional case)

- Add jumbo-frame context to VLAN MTU values (storage and client VLANs)
  so operators on 1GbE or mixed hardware know to set mtu: 1500

- Reduce placeholder disk count in host_vars from 12 to 4 with an
  explicit comment that any count is supported; document the 1:1
  positional mirroring requirement between the two nodes

https://claude.ai/code/session_01ASpaLaFvYJz2JmqvfwMZ92