### PR TITLE
Fix 14 simplicity, maintainability, and robustness issues

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -125,29 +125,3 @@ firewall_rate_limit_enabled: true
 # NFSv3 ports in firewall (111/tcp+udp, 20048) — only needed if nfs_v3_enabled: true
 # (mirrored from services role; set both consistently)
 nfs_v3_enabled: false
-
-# ---------------------------------------------------------------------------
-# Monitoring — disk health and ECC memory
-# ---------------------------------------------------------------------------
-smart_monitoring_enabled: true     # SMART disk health exporter (storage nodes only)
-ras_monitoring_enabled: false      # ECC memory monitoring via rasdaemon (not all hardware has ECC)
-
-# Alertmanager ntfy integration config — set URL to enable alertmanager.yml generation
-alertmanager_ntfy_url: ""
-
-# ---------------------------------------------------------------------------
-# Monitoring — node_exporter TLS (optional)
-# ---------------------------------------------------------------------------
-node_exporter_tls_enabled: false
-# node_exporter_cert_file: /etc/ssl/certs/node-exporter.crt
-# node_exporter_key_file: /etc/ssl/private/node-exporter.key
-# node_exporter_basic_auth_users:
-#   prometheus: "$2b$12$..."   # bcrypt hash
-
-# ---------------------------------------------------------------------------
-# Cockpit — custom TLS certificate (optional)
-# ---------------------------------------------------------------------------
-# By default Cockpit uses a self-signed cert. Provide paths to deploy your own.
-# Paths are on the Ansible controller (src:), not the target node.
-# cockpit_tls_cert_file: "/path/on/ansible/controller/cert.pem"
-# cockpit_tls_key_file:  "/path/on/ansible/controller/key.pem"

--- a/group_vars/storage_nodes.yml
+++ b/group_vars/storage_nodes.yml
@@ -49,9 +49,6 @@ zfs_scrub_randomized_delay_sec: 1800   # 30 minutes random delay
 zfs_scrub_skip_on_degraded: true       # Skip if pool is degraded
 zfs_scrub_min_interval_days: 25        # Minimum days between scrubs
 
-# ZFS scrub monitoring (Prometheus metrics)
-zfs_scrub_monitoring_enabled: true     # Export scrub metrics for Prometheus
-
 # Datasets to create after pool exists
 zfs_datasets:
   - name: "{{ zfs_pool_name }}/nfs"
@@ -87,11 +84,17 @@ iscsi_mutual_chap_enabled: true
 iscsi_mutual_chap_user: "iscsi-target-user"
 iscsi_mutual_chap_password: "CHANGEME-vault-this"  # ansible-vault in production — MUST differ from iscsi_chap_password
 
-# open-iscsi initiator aggressive-safe timeouts
+# open-iscsi initiator aggressive-safe timeouts (tune for your network)
+# iscsi_replacement_timeout defaults to 5s in iscsi-initiator role (see defaults/main.yml)
 iscsi_replacement_timeout: 5
 iscsi_noop_out_interval: 2
 iscsi_noop_out_timeout: 2
 iscsi_login_timeout: 10       # Reduced: replacement_timeout (5s) handles path failures; this covers initial login
+
+# iSCSI queue depth — tune for storage device type
+# SATA SSD: 32-64, NVMe-backed storage: 64-128
+iscsi_queue_depth: 32
+iscsi_cmds_max: 128
 
 # ---------------------------------------------------------------------------
 # iSCSI — Client-facing target (Pacemaker-managed)
@@ -115,10 +118,6 @@ nfs_exports:
     options: "rw,sync,no_subtree_check,root_squash,sec=sys"
 
 nfs_bind_ip: "{{ vip_nfs }}"
-nfs_threads: 8
-nfs_v3_enabled: false
-nfs_v4_enabled: true
-nfs_v41_enabled: true
 
 # ---------------------------------------------------------------------------
 # Samba / SMB
@@ -126,8 +125,6 @@ nfs_v41_enabled: true
 smb_bind_ip: "{{ vip_smb }}"
 smb_workgroup: "HOMELAB"
 smb_server_string: "HA SAN SMB"
-smb_min_protocol: "SMB3"
-smb_signing: "required"
 smb_encrypt: "required"   # "desired" if some clients can't do SMB3 encryption
 smb_shares:
   - name: shared
@@ -206,9 +203,8 @@ stonith_nodes:
 # ---------------------------------------------------------------------------
 # Pacemaker resource configuration
 # ---------------------------------------------------------------------------
-pacemaker_resource_stickiness: 200
 pacemaker_preferred_node: "storage-a"  # soft preference, not hard pin
-
+pacemaker_resource_stickiness: 200
 # Seconds to wait after 'pcs node standby' during shutdown for resources to migrate
 # before pacemaker itself stops. Planned migration takes ~5-8s; 15s is conservative.
 pacemaker_standby_drain_seconds: 15
@@ -263,26 +259,6 @@ syncoid_targets: []
 #     destination: "backup@remote-host:backup-pool/san-pool-nfs"
 
 # ---------------------------------------------------------------------------
-# iSCSI — Client-facing target optional CHAP
-# ---------------------------------------------------------------------------
-iscsi_client_chap_enabled: false
-iscsi_client_chap_user: ""
-iscsi_client_chap_password: ""      # vault this if enabled
-
-# ---------------------------------------------------------------------------
-# NFS grace period (seconds) — time for clients to reclaim locks after failover
-# ---------------------------------------------------------------------------
-nfs_grace_time: 45      # Reduced from 90s default for faster client reconnect
-nfs_lease_time: 45      # Keep in sync with grace_time
-
-# ---------------------------------------------------------------------------
-# iSCSI queue depth and command limit (tune for storage device type)
-# ---------------------------------------------------------------------------
-# SATA SSD: 32-64, NVMe-backed storage: 64-128
-iscsi_queue_depth: 32
-iscsi_cmds_max: 128
-
-# ---------------------------------------------------------------------------
 # TCP / Network tuning for 40GbE iSCSI
 # ---------------------------------------------------------------------------
 tcp_tunables:
@@ -290,5 +266,5 @@ tcp_tunables:
   net.core.wmem_max: 16777216
   net.ipv4.tcp_rmem: "4096 87380 16777216"
   net.ipv4.tcp_wmem: "4096 65536 16777216"
-  net.ipv4.tcp_congestion_control: bbr    # Requires tcp_bbr module (loaded by hardening role)
+  net.ipv4.tcp_congestion_control: bbr    # Requires tcp_bbr module (loaded by networking role)
   net.core.default_qdisc: fq             # Required for BBR to work optimally

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -10,19 +10,14 @@
       - cockpit-packagekit
     state: present
 
-- name: Enable Cockpit socket (on quorum node only)
-  ansible.builtin.systemd:
-    name: cockpit.socket
-    enabled: true
-    state: started
-  when: inventory_hostname not in groups['storage_nodes']
-
+# Play 5 in site.yml targets storage_nodes only.
+# Pacemaker manages the Cockpit socket there (VIP follows the active node).
+# To enable Cockpit on the quorum node, add a separate play targeting quorum_node.
 - name: Disable Cockpit auto-start on storage nodes (Pacemaker manages this)
   ansible.builtin.systemd:
     name: cockpit.socket
     enabled: false
     state: stopped
-  when: inventory_hostname in groups['storage_nodes']
 
 # ─── 45Drives Houston plugins ─────────────────────────────────────────────
 # These are optional — install from 45Drives repo.
@@ -33,11 +28,17 @@
     url: https://repo.45drives.com/key/gpg
     dest: /usr/share/keyrings/45drives-archive-keyring.gpg
     mode: "0644"
+    checksum: "{{ fortyfive_drives_gpg_checksum | default(omit) }}"
+    # Set fortyfive_drives_gpg_checksum in group_vars to enforce integrity, e.g.:
+    #   fortyfive_drives_gpg_checksum: "sha256:abc123..."
+    # Obtain with: curl -s https://repo.45drives.com/key/gpg | sha256sum
   register: key_download
 
 - name: Add 45Drives apt repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/45drives-archive-keyring.gpg] https://repo.45drives.com/debian focal main"
+    repo: >-
+      deb [arch=amd64 signed-by=/usr/share/keyrings/45drives-archive-keyring.gpg]
+      https://repo.45drives.com/debian {{ ansible_distribution_release }} main
     state: present
     filename: 45drives
   when: key_download is succeeded

--- a/roles/hardening/tasks/main.yml
+++ b/roles/hardening/tasks/main.yml
@@ -18,19 +18,6 @@
     mode: "0644"
   notify: reload sysctl
 
-# ─── TCP performance tuning (storage nodes only) ──────────────────────────
-- name: Deploy TCP tuning for 40GbE
-  ansible.builtin.copy:
-    dest: /etc/sysctl.d/91-tcp-tuning.conf
-    mode: "0644"
-    content: |
-      # Managed by Ansible — 40GbE iSCSI TCP tuning
-      {% for key, value in tcp_tunables.items() %}
-      {{ key }} = {{ value }}
-      {% endfor %}
-  when: tcp_tunables is defined
-  notify: reload sysctl
-
 # ─── nftables Firewall ────────────────────────────────────────────────────
 - name: Install nftables
   ansible.builtin.apt:
@@ -72,16 +59,6 @@
   loop:
     - net.ipv6.conf.all.disable_ipv6
     - net.ipv6.conf.default.disable_ipv6
-
-# ─── TCP BBR congestion control module ────────────────────────────────────
-- name: Load tcp_bbr kernel module
-  community.general.modprobe:
-    name: tcp_bbr
-    state: present
-    persistent: present
-  when: >
-    tcp_tunables is defined and
-    tcp_tunables.get('net.ipv4.tcp_congestion_control', '') == 'bbr'
 
 # ─── auditd ───────────────────────────────────────────────────────────────
 - name: Install auditd

--- a/roles/iscsi-target/tasks/main.yml
+++ b/roles/iscsi-target/tasks/main.yml
@@ -26,11 +26,13 @@
   failed_when: false
   changed_when: false
 
-- name: Run LIO target setup (first time only)
+- name: Run LIO target setup (first time or forced)
   ansible.builtin.command:
     cmd: /root/setup-lio-target.sh
-  when: lio_check.rc != 0
+  when: lio_check.rc != 0 or (force_iscsi_reconfigure | default(false) | bool)
   notify: save lio config
+  # To force re-run after a failed partial setup:
+  #   ansible-playbook -i inventory.yml site.yml --tags storage -e force_iscsi_reconfigure=true
 
 - name: Set permissions on saveconfig.json
   ansible.builtin.file:

--- a/roles/monitoring/tasks/deploy_timer_exporter.yml
+++ b/roles/monitoring/tasks/deploy_timer_exporter.yml
@@ -1,0 +1,47 @@
+---
+# Reusable task file for deploying a script-based timer exporter.
+# Called via include_tasks with loop_var 'exporter'.
+#
+# Expected exporter dict keys:
+#   name         — base name used for script, .service, and .timer (required)
+#   enabled      — boolean condition (required)
+#   storage_only — true to limit to storage_nodes group (default: false)
+
+- name: "Deploy {{ exporter.name }} script"
+  ansible.builtin.template:
+    src: "{{ exporter.name }}.sh.j2"
+    dest: "/usr/local/bin/{{ exporter.name }}"
+    mode: "0755"
+  when:
+    - exporter.enabled | bool
+    - not (exporter.storage_only | default(false)) or inventory_hostname in groups['storage_nodes']
+
+- name: "Deploy {{ exporter.name }} systemd service"
+  ansible.builtin.template:
+    src: "{{ exporter.name }}.service.j2"
+    dest: "/etc/systemd/system/{{ exporter.name }}.service"
+    mode: "0644"
+  when:
+    - exporter.enabled | bool
+    - not (exporter.storage_only | default(false)) or inventory_hostname in groups['storage_nodes']
+  notify: reload systemd
+
+- name: "Deploy {{ exporter.name }} systemd timer"
+  ansible.builtin.template:
+    src: "{{ exporter.name }}.timer.j2"
+    dest: "/etc/systemd/system/{{ exporter.name }}.timer"
+    mode: "0644"
+  when:
+    - exporter.enabled | bool
+    - not (exporter.storage_only | default(false)) or inventory_hostname in groups['storage_nodes']
+  notify: reload systemd
+
+- name: "Enable {{ exporter.name }} timer"
+  ansible.builtin.systemd:
+    name: "{{ exporter.name }}.timer"
+    enabled: true
+    state: started
+    daemon_reload: true
+  when:
+    - exporter.enabled | bool
+    - not (exporter.storage_only | default(false)) or inventory_hostname in groups['storage_nodes']

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# roles/monitoring/tasks/main.yml — Prometheus node_exporter
+# roles/monitoring/tasks/main.yml — Prometheus exporters for HA SAN nodes
 
 - name: Install prometheus-node-exporter
   ansible.builtin.apt:
@@ -47,137 +47,31 @@
     enabled: true
     state: started
 
-# ─── ZFS Scrub Metrics Exporter ────────────────────────────────────────────
-- name: Deploy ZFS scrub metrics exporter script
-  ansible.builtin.template:
-    src: zfs-scrub-exporter.sh.j2
-    dest: /usr/local/bin/zfs-scrub-exporter
-    mode: "0755"
-  when: zfs_scrub_monitoring_enabled | default(true)
+# ─── Script-based timer exporters ─────────────────────────────────────────
+# Each exporter follows the same pattern: script + .service + .timer + enable.
+# See tasks/deploy_timer_exporter.yml for the shared implementation.
+- name: Deploy timer-based exporters
+  ansible.builtin.include_tasks: deploy_timer_exporter.yml
+  loop:
+    - name: zfs-scrub-exporter
+      enabled: "{{ zfs_scrub_monitoring_enabled | default(true) }}"
+      storage_only: true
+    - name: reboot-required-exporter
+      enabled: true
+      storage_only: false
+    - name: stonith-probe
+      enabled: true
+      storage_only: true
+    - name: smart-exporter
+      enabled: "{{ smart_monitoring_enabled | default(true) }}"
+      storage_only: true
+    - name: ras-exporter
+      enabled: "{{ ras_monitoring_enabled | default(false) }}"
+      storage_only: false
+  loop_control:
+    loop_var: exporter
 
-- name: Deploy ZFS scrub exporter systemd service
-  ansible.builtin.template:
-    src: zfs-scrub-exporter.service.j2
-    dest: /etc/systemd/system/zfs-scrub-exporter.service
-    mode: "0644"
-  when: zfs_scrub_monitoring_enabled | default(true)
-  notify: reload systemd
-
-- name: Deploy ZFS scrub exporter systemd timer
-  ansible.builtin.template:
-    src: zfs-scrub-exporter.timer.j2
-    dest: /etc/systemd/system/zfs-scrub-exporter.timer
-    mode: "0644"
-  when: zfs_scrub_monitoring_enabled | default(true)
-  notify: reload systemd
-
-- name: Enable and start ZFS scrub exporter timer
-  ansible.builtin.systemd:
-    name: zfs-scrub-exporter.timer
-    enabled: true
-    state: started
-    daemon_reload: true
-  when: zfs_scrub_monitoring_enabled | default(true)
-
-# ─── Reboot-Required Exporter ──────────────────────────────────────────────
-- name: Deploy reboot-required metrics exporter script
-  ansible.builtin.template:
-    src: reboot-required-exporter.sh.j2
-    dest: /usr/local/bin/reboot-required-exporter
-    mode: "0755"
-
-- name: Deploy reboot-required exporter systemd service
-  ansible.builtin.template:
-    src: reboot-required-exporter.service.j2
-    dest: /etc/systemd/system/reboot-required-exporter.service
-    mode: "0644"
-  notify: reload systemd
-
-- name: Deploy reboot-required exporter systemd timer
-  ansible.builtin.template:
-    src: reboot-required-exporter.timer.j2
-    dest: /etc/systemd/system/reboot-required-exporter.timer
-    mode: "0644"
-  notify: reload systemd
-
-- name: Enable and start reboot-required exporter timer
-  ansible.builtin.systemd:
-    name: reboot-required-exporter.timer
-    enabled: true
-    state: started
-    daemon_reload: true
-
-# ─── STONITH Reachability Probe ────────────────────────────────────────────
-- name: Deploy STONITH probe script
-  ansible.builtin.template:
-    src: stonith-probe.sh.j2
-    dest: /usr/local/bin/stonith-probe
-    mode: "0755"
-  when: inventory_hostname in groups['storage_nodes']
-
-- name: Deploy STONITH probe systemd service
-  ansible.builtin.template:
-    src: stonith-probe.service.j2
-    dest: /etc/systemd/system/stonith-probe.service
-    mode: "0644"
-  when: inventory_hostname in groups['storage_nodes']
-  notify: reload systemd
-
-- name: Deploy STONITH probe systemd timer
-  ansible.builtin.template:
-    src: stonith-probe.timer.j2
-    dest: /etc/systemd/system/stonith-probe.timer
-    mode: "0644"
-  when: inventory_hostname in groups['storage_nodes']
-  notify: reload systemd
-
-- name: Enable and start STONITH probe timer
-  ansible.builtin.systemd:
-    name: stonith-probe.timer
-    enabled: true
-    state: started
-    daemon_reload: true
-  when: inventory_hostname in groups['storage_nodes']
-
-# ─── SMART Disk Health Monitoring ─────────────────────────────────────────
-- name: Install smartmontools
-  ansible.builtin.apt:
-    name: smartmontools
-    state: present
-  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
-
-- name: Deploy SMART health exporter script
-  ansible.builtin.template:
-    src: smart-exporter.sh.j2
-    dest: /usr/local/bin/smart-exporter
-    mode: "0755"
-  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
-
-- name: Deploy SMART exporter systemd service
-  ansible.builtin.template:
-    src: smart-exporter.service.j2
-    dest: /etc/systemd/system/smart-exporter.service
-    mode: "0644"
-  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
-  notify: reload systemd
-
-- name: Deploy SMART exporter systemd timer
-  ansible.builtin.template:
-    src: smart-exporter.timer.j2
-    dest: /etc/systemd/system/smart-exporter.timer
-    mode: "0644"
-  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
-  notify: reload systemd
-
-- name: Enable SMART exporter timer
-  ansible.builtin.systemd:
-    name: smart-exporter.timer
-    enabled: true
-    state: started
-    daemon_reload: true
-  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
-
-# ─── Memory ECC / RAS Monitoring ───────────────────────────────────────────
+# ─── rasdaemon (required by ras-exporter) ──────────────────────────────────
 - name: Install rasdaemon
   ansible.builtin.apt:
     name: rasdaemon
@@ -191,36 +85,12 @@
     state: started
   when: ras_monitoring_enabled | default(false)
 
-- name: Deploy RAS (ECC) exporter script
-  ansible.builtin.template:
-    src: ras-exporter.sh.j2
-    dest: /usr/local/bin/ras-exporter
-    mode: "0755"
-  when: ras_monitoring_enabled | default(false)
-
-- name: Deploy RAS exporter systemd service
-  ansible.builtin.template:
-    src: ras-exporter.service.j2
-    dest: /etc/systemd/system/ras-exporter.service
-    mode: "0644"
-  when: ras_monitoring_enabled | default(false)
-  notify: reload systemd
-
-- name: Deploy RAS exporter systemd timer
-  ansible.builtin.template:
-    src: ras-exporter.timer.j2
-    dest: /etc/systemd/system/ras-exporter.timer
-    mode: "0644"
-  when: ras_monitoring_enabled | default(false)
-  notify: reload systemd
-
-- name: Enable RAS exporter timer
-  ansible.builtin.systemd:
-    name: ras-exporter.timer
-    enabled: true
-    state: started
-    daemon_reload: true
-  when: ras_monitoring_enabled | default(false)
+# ─── smartmontools (required by smart-exporter) ────────────────────────────
+- name: Install smartmontools
+  ansible.builtin.apt:
+    name: smartmontools
+    state: present
+  when: smart_monitoring_enabled | default(true) and inventory_hostname in groups['storage_nodes']
 
 # ─── HA Cluster Exporter (Pacemaker/Corosync metrics) ──────────────────────
 - name: Install prometheus-hacluster-exporter
@@ -253,5 +123,5 @@
   when: >
     alertmanager_ntfy_url is defined and
     alertmanager_ntfy_url | length > 0 and
-    inventory_hostname == pacemaker_preferred_node | default('storage-a')
+    inventory_hostname == pacemaker_preferred_node
   run_once: true

--- a/roles/networking/handlers/main.yml
+++ b/roles/networking/handlers/main.yml
@@ -4,3 +4,7 @@
     name: systemd-networkd
     state: restarted
   when: networking_restart_on_change | default(false)
+
+- name: reload sysctl
+  ansible.builtin.command:
+    cmd: sysctl --system

--- a/roles/networking/tasks/main.yml
+++ b/roles/networking/tasks/main.yml
@@ -1,11 +1,34 @@
 ---
-# roles/networking/tasks/main.yml — Optional network interface configuration
-# Only runs when networking_manage: true
-# Configures VLANs and MTU via systemd-networkd.
+# roles/networking/tasks/main.yml — Network interface configuration + TCP tuning
 #
-# WARNING: Enabling this on a running system may disrupt connectivity.
+# Interface management is opt-in (networking_manage: true).
+# TCP performance tuning runs unconditionally on storage nodes when tcp_tunables
+# is defined — it does not require networking_manage to be enabled.
+#
+# WARNING: Enabling networking_manage on a running system may disrupt connectivity.
 #          Set networking_restart_on_change: true only during initial deployment.
 
+# ─── TCP performance tuning (storage nodes) ───────────────────────────────
+# Lives here (not in hardening) because this is performance configuration,
+# not security hardening. Runs whenever tcp_tunables is defined.
+- name: Deploy TCP tuning sysctl settings
+  ansible.builtin.template:
+    src: 91-tcp-tuning.conf.j2
+    dest: /etc/sysctl.d/91-tcp-tuning.conf
+    mode: "0644"
+  when: tcp_tunables is defined
+  notify: reload sysctl
+
+- name: Load tcp_bbr kernel module
+  community.general.modprobe:
+    name: tcp_bbr
+    state: present
+    persistent: present
+  when: >
+    tcp_tunables is defined and
+    tcp_tunables.get('net.ipv4.tcp_congestion_control', '') == 'bbr'
+
+# ─── Interface configuration (opt-in) ─────────────────────────────────────
 - name: Install systemd-networkd
   ansible.builtin.apt:
     name: systemd-networkd

--- a/roles/networking/templates/91-tcp-tuning.conf.j2
+++ b/roles/networking/templates/91-tcp-tuning.conf.j2
@@ -1,0 +1,5 @@
+# Managed by Ansible — 40GbE iSCSI TCP tuning
+# Node: {{ inventory_hostname }}
+{% for key, value in tcp_tunables.items() %}
+{{ key }} = {{ value }}
+{% endfor %}

--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -56,7 +56,7 @@
       {% endfor %}
       -u hacluster -p {{ hacluster_password }}
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   changed_when: false
   failed_when: false
 
@@ -67,7 +67,7 @@
   changed_when: false
   failed_when: false
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
 
 - name: Create cluster (first time only)
   ansible.builtin.command:
@@ -77,24 +77,32 @@
       {{ node.name }} addr={{ node.ring0_addr }}
       {% endfor %}
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   when: cluster_status.rc != 0
 
 - name: Start cluster on all nodes
   ansible.builtin.command:
     cmd: pcs cluster start --all
+  register: cluster_start
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   changed_when: false
-  failed_when: false
+  failed_when: >
+    cluster_start.rc != 0 and
+    'already' not in (cluster_start.stderr | lower) and
+    'already' not in (cluster_start.stdout | lower)
 
 - name: Enable cluster auto-start on all nodes
   ansible.builtin.command:
     cmd: pcs cluster enable --all
+  register: cluster_enable
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   changed_when: false
-  failed_when: false
+  failed_when: >
+    cluster_enable.rc != 0 and
+    'already' not in (cluster_enable.stderr | lower) and
+    'already' not in (cluster_enable.stdout | lower)
 
 # ─── Cluster properties and STONITH (run once) ────────────────────────────
 - name: Configure cluster properties
@@ -104,7 +112,7 @@
     - "stonith-enabled=true"
     - "no-quorum-policy=stop"
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   changed_when: false
   failed_when: false
 
@@ -112,7 +120,7 @@
   ansible.builtin.command:
     cmd: pcs resource defaults update resource-stickiness={{ pacemaker_resource_stickiness }}
   run_once: true
-  delegate_to: "{{ pacemaker_preferred_node | default('storage-a') }}"
+  delegate_to: "{{ pacemaker_preferred_node }}"
   changed_when: false
   failed_when: false
 
@@ -121,7 +129,7 @@
     src: configure-resources.sh.j2
     dest: /root/configure-pacemaker-resources.sh
     mode: "0700"
-  when: inventory_hostname == pacemaker_preferred_node | default('storage-a')
+  when: inventory_hostname == pacemaker_preferred_node
 
 # ─── Graceful standby on shutdown (storage nodes only) ────────────────────
 - name: Deploy pacemaker-node-standby systemd service
@@ -153,4 +161,4 @@
     src: configure-stonith.sh.j2
     dest: /root/configure-stonith.sh
     mode: "0700"
-  when: inventory_hostname == pacemaker_preferred_node | default('storage-a')
+  when: inventory_hostname == pacemaker_preferred_node

--- a/roles/services/tasks/main.yml
+++ b/roles/services/tasks/main.yml
@@ -16,34 +16,25 @@
     enabled: false
 
 # ─── Shared cluster configuration directory ───────────────────────────────
-- name: Create cluster config directory on shared pool
+# These tasks write to the ZFS pool, which exists only on one node at a time.
+# run_once + delegate_to ensures they execute on the node that has the pool mounted.
+- name: Create cluster config directory structure on shared pool
   ansible.builtin.file:
-    path: "/{{ zfs_pool_name }}/cluster-config"
+    path: "/{{ zfs_pool_name }}/cluster-config/{{ item }}"
     state: directory
     mode: "0755"
     owner: root
     group: root
+  loop:
+    - ""
+    - "nfs"
+    - "samba"
+    - "samba/private"
   when: >
     ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
   ignore_errors: true
-
-- name: Create NFS config directory
-  ansible.builtin.file:
-    path: "/{{ zfs_pool_name }}/cluster-config/nfs"
-    state: directory
-    mode: "0755"
-  when: >
-    ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
-  ignore_errors: true
-
-- name: Create Samba config directory
-  ansible.builtin.file:
-    path: "/{{ zfs_pool_name }}/cluster-config/samba"
-    state: directory
-    mode: "0755"
-  when: >
-    ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
-  ignore_errors: true
+  run_once: true
+  delegate_to: "{{ pacemaker_preferred_node }}"
 
 - name: Initialize exports on shared storage (if not exists)
   ansible.builtin.template:
@@ -55,19 +46,24 @@
     ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
   ignore_errors: true
   run_once: true
+  delegate_to: "{{ pacemaker_preferred_node }}"
 
-- name: Remove existing exports file (if regular file)
-  ansible.builtin.stat:
-    path: /etc/exports
-  register: exports_stat
+- name: Initialize smb.conf on shared storage (if not exists)
+  ansible.builtin.template:
+    src: smb.conf.j2
+    dest: "/{{ zfs_pool_name }}/cluster-config/samba/smb.conf"
+    mode: "0644"
+    force: false
+  when: >
+    ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
+  ignore_errors: true
+  run_once: true
+  delegate_to: "{{ pacemaker_preferred_node }}"
 
-- name: Remove old exports if it's a regular file
-  ansible.builtin.file:
-    path: /etc/exports
-    state: absent
-  when: exports_stat.stat.exists and not exports_stat.stat.islnk
-
-- name: Symlink exports from shared storage
+# ─── Symlink local config paths to shared storage ─────────────────────────
+# force: true replaces an existing regular file with the symlink in one step,
+# making a separate stat + conditional-remove pattern unnecessary.
+- name: Symlink /etc/exports to shared storage
   ansible.builtin.file:
     src: "/{{ zfs_pool_name }}/cluster-config/nfs/exports"
     dest: /etc/exports
@@ -96,56 +92,14 @@
     - smbd
     - nmbd
 
-- name: Initialize smb.conf on shared storage (if not exists)
-  ansible.builtin.template:
-    src: smb.conf.j2
-    dest: "/{{ zfs_pool_name }}/cluster-config/samba/smb.conf"
-    mode: "0644"
-    force: false
-  when: >
-    ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
-  ignore_errors: true
-  run_once: true
-
-- name: Create Samba private directory on shared storage
-  ansible.builtin.file:
-    path: "/{{ zfs_pool_name }}/cluster-config/samba/private"
-    state: directory
-    mode: "0700"
-  when: >
-    ansible_mounts | selectattr('mount', 'equalto', '/' + zfs_pool_name) | list | length > 0
-  ignore_errors: true
-
-- name: Remove existing smb.conf (if regular file)
-  ansible.builtin.stat:
-    path: /etc/samba/smb.conf
-  register: smb_conf_stat
-
-- name: Remove old smb.conf if it's a regular file
-  ansible.builtin.file:
-    path: /etc/samba/smb.conf
-    state: absent
-  when: smb_conf_stat.stat.exists and not smb_conf_stat.stat.islnk
-
-- name: Symlink smb.conf from shared storage
+- name: Symlink /etc/samba/smb.conf to shared storage
   ansible.builtin.file:
     src: "/{{ zfs_pool_name }}/cluster-config/samba/smb.conf"
     dest: /etc/samba/smb.conf
     state: link
     force: true
 
-- name: Remove existing Samba private directory (if regular directory)
-  ansible.builtin.stat:
-    path: /var/lib/samba/private
-  register: samba_private_stat
-
-- name: Remove old Samba private directory if it's a regular directory
-  ansible.builtin.file:
-    path: /var/lib/samba/private
-    state: absent
-  when: samba_private_stat.stat.exists and not samba_private_stat.stat.islnk
-
-- name: Symlink Samba private directory from shared storage
+- name: Symlink /var/lib/samba/private to shared storage
   ansible.builtin.file:
     src: "/{{ zfs_pool_name }}/cluster-config/samba/private"
     dest: /var/lib/samba/private

--- a/roles/zfs/tasks/main.yml
+++ b/roles/zfs/tasks/main.yml
@@ -83,6 +83,27 @@
         enabled: true
         state: started
 
+# ─── ZFS Dataset Creation ──────────────────────────────────────────────────
+# Only runs when the pool is imported. Datasets are idempotent (state: present).
+# Properties listed in zfs_datasets are applied on every run, so this also
+# enforces dataset configuration drift correction.
+- name: Check if ZFS pool is imported
+  ansible.builtin.command:
+    cmd: zpool list {{ zfs_pool_name }}
+  register: zpool_check
+  changed_when: false
+  failed_when: false
+
+- name: Create ZFS datasets
+  community.general.zfs:
+    name: "{{ item.name }}"
+    state: present
+    extra_zfs_properties: "{{ item.properties | default({}) }}"
+  loop: "{{ zfs_datasets | default([]) }}"
+  when:
+    - zfs_datasets is defined
+    - zpool_check.rc == 0
+
 # ─── ZFS Scrub Automation ──────────────────────────────────────────────────
 - name: Deploy ZFS scrub wrapper script
   ansible.builtin.template:

--- a/site.yml
+++ b/site.yml
@@ -46,17 +46,31 @@
           - "'CHANGEME' not in (hacluster_password | string)"
           - "'CHANGEME' not in (iscsi_chap_password | string)"
           - "'CHANGEME' not in (iscsi_mutual_chap_password | string)"
+          - stonith_passwords_ok
+          - "'your-key-here' not in (admin_ssh_pubkey | string)"
+          - admin_ssh_pubkey | length > 20
         fail_msg: |
           SECURITY ERROR: Default placeholder credentials detected.
           Update before deploying:
             hacluster_password         — ansible-vault encrypt_string 'yourpassword'
             iscsi_chap_password        — ansible-vault encrypt_string 'yourpassword'
             iscsi_mutual_chap_password — ansible-vault encrypt_string 'yourpassword'
-          Also verify STONITH passwords in stonith_nodes dict.
+            stonith_nodes.<node>.password — ansible-vault encrypt_string 'yourpassword'
+            admin_ssh_pubkey           — replace with your actual SSH public key
       vars:
         hacluster_password: "{{ hostvars[groups['storage_nodes'][0]]['hacluster_password'] | default('') }}"
         iscsi_chap_password: "{{ hostvars[groups['storage_nodes'][0]]['iscsi_chap_password'] | default('') }}"
         iscsi_mutual_chap_password: "{{ hostvars[groups['storage_nodes'][0]]['iscsi_mutual_chap_password'] | default('') }}"
+        _stonith_nodes: "{{ hostvars[groups['storage_nodes'][0]]['stonith_nodes'] | default({}) }}"
+        stonith_passwords_ok: >-
+          {{
+            _stonith_nodes.values()
+            | selectattr('password', 'defined')
+            | map(attribute='password')
+            | map('string')
+            | select('search', 'CHANGEME')
+            | list | length == 0
+          }}
 
 # ─── Pre-run: Warn if cluster is already deployed and degraded ──────────────
 - name: "Pre-run cluster health check (storage nodes)"


### PR DESCRIPTION
High severity (robustness):
- R1: Fix 45Drives apt repo using Ubuntu 'focal' codename on Debian 12;
  now uses {{ ansible_distribution_release }} (resolves to 'bookworm')
- R2: Add optional checksum verification for 45Drives GPG key download
  via fortyfive_drives_gpg_checksum variable
- R3: Extend pre-flight assert to check STONITH node passwords for
  CHANGEME placeholders (loops over stonith_nodes.values())
- R4: Replace failed_when: false on pcs cluster start/enable with proper
  failed_when that still tolerates 'already' in output
- R5: Add delegate_to: pacemaker_preferred_node to run_once shared-storage
  init tasks so they execute on the node that has the pool mounted
- R6: Add admin_ssh_pubkey placeholder check to pre-flight assert

Medium severity (maintainability/robustness):
- R7: Add ZFS dataset creation tasks to zfs role using community.general.zfs;
  previously datasets were only created by the manual create-pool.sh script
- R8: Add force_iscsi_reconfigure flag to allow re-running LIO target setup
  after a partial failure
- M1: Refactor monitoring role — extract the 5 timer-based exporters
  (zfs-scrub, reboot-required, stonith-probe, smart, ras) into a shared
  deploy_timer_exporter.yml include_tasks file, eliminating ~150 lines of
  repeated deploy-script/deploy-service/deploy-timer/enable-timer blocks
- M2+M3: Move TCP sysctl tuning and BBR module loading out of the hardening
  role (wrong conceptual home) into the networking role; convert the
  inline Jinja2 copy: content: block to a proper template file
  (roles/networking/templates/91-tcp-tuning.conf.j2)
- M4: Remove unreachable 'Enable Cockpit socket on quorum node' task block;
  play 5 targets storage_nodes only so the when condition was never true

Low severity (simplicity):
- S1: Remove monitoring variables from all.yml that duplicate role defaults
  (smart_monitoring_enabled, ras_monitoring_enabled, alertmanager_ntfy_url,
  node_exporter_tls_enabled); remove from storage_nodes.yml variables
  identical to their role defaults (nfs_threads, nfs_grace_time,
  nfs_lease_time, smb_min_protocol, smb_signing, iscsi_client_chap_*)
- S2: Remove redundant | default('storage-a') from all 8 pacemaker task
  delegate_to/when expressions — pacemaker_preferred_node is always defined
- S3: Simplify three-step stat+remove+symlink pattern in services role to
  a single ansible.builtin.file with force: true — the force parameter
  already handles replacing a regular file with a symlink

https://claude.ai/code/session_01NKwebij61onyePR8hbevPX