### PR TITLE
Fix 3 bugs from recent merges: Jinja2 syntax errors and missing handler

### DIFF
--- a/roles/iscsi-initiator/templates/create-pool.sh.j2
+++ b/roles/iscsi-initiator/templates/create-pool.sh.j2
@@ -115,7 +115,9 @@ echo "=== Creating ZFS pool: $POOL ==="
 MIRROR_ARGS=""
 for i in "${!LOCAL_DISKS[@]}"; do
   MIRROR_ARGS+="  mirror ${LOCAL_DISKS[$i]} ${REMOTE_DISKS[$i]}"
+{% raw %}
   if [[ $i -lt $((${#LOCAL_DISKS[@]} - 1)) ]]; then
+{% endraw %}
     MIRROR_ARGS+=" \\"$'\n'
   fi
 done

--- a/roles/monitoring/templates/smart-exporter.sh.j2
+++ b/roles/monitoring/templates/smart-exporter.sh.j2
@@ -77,10 +77,12 @@ spare = nvme.get('available_spare', 0)
 used = nvme.get('percentage_used', 0)
 poh = nvme.get('power_on_hours', 0)
 labels = '${LABELS}'
+{% raw %}
 print(f'node_disk_smart_temperature_celsius{{{labels}}} {temp}')
 print(f'node_disk_nvme_available_spare_percent{{{labels}}} {spare}')
 print(f'node_disk_nvme_percentage_used{{{labels}}} {used}')
 print(f'node_disk_smart_power_on_hours_total{{{labels}}} {poh}')
+{% endraw %}
 " 2>/dev/null || true
     else
       # SATA/SAS attributes — parse ata_smart_attributes array
@@ -97,10 +99,12 @@ poh = attrs.get('Power_On_Hours', 0)
 if temp is not None:
     temp = temp & 0xFF
 labels = '${LABELS}'
+{% raw %}
 if temp is not None:
     print(f'node_disk_smart_temperature_celsius{{{labels}}} {temp}')
 print(f'node_disk_smart_reallocated_sectors_total{{{labels}}} {realloc}')
 print(f'node_disk_smart_power_on_hours_total{{{labels}}} {poh}')
+{% endraw %}
 " 2>/dev/null || true
     fi
   done

--- a/roles/pacemaker/handlers/main.yml
+++ b/roles/pacemaker/handlers/main.yml
@@ -5,3 +5,7 @@
   ansible.builtin.command:
     cmd: corosync-cfgtool -R
   changed_when: true
+
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true


### PR DESCRIPTION
- smart-exporter.sh.j2: Wrap Python f-strings in {% raw %} blocks to prevent
  Jinja2 from interpreting triple braces {{{labels}}} as template syntax
- create-pool.sh.j2: Wrap bash ${#LOCAL_DISKS[@]} in {% raw %} block to
  prevent Jinja2 from interpreting {# as a comment start tag
- pacemaker/handlers: Add missing 'reload systemd' handler referenced by
  the pacemaker-node-standby deploy task (pacemaker role runs alone in
  Play 3, so handlers from zfs/monitoring roles are not available)

https://claude.ai/code/session_01Vo5f3xpnStjnAhx7fJw2Bq