### PR TITLE
Fix README inaccuracies in Post-Deployment Testing and Monitoring sec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ After the manual steps are complete, run through this checklist:
 pcs status
 
 # Test planned failover (~5-8s)
-pcs resource move san-services storage-b
-pcs resource clear san-services
+pcs resource move zfs-pool storage-b
+pcs resource clear zfs-pool
 
 # Test unplanned failover (~10-12s) — PULL THE POWER CORD on active node
 # Verify clients reconnect within 15-25s total


### PR DESCRIPTION
…tions

- Correct Pacemaker resource group name: san-resources → san-services
- Replace bogus stonith_admin dry-run with correct pcs stonith fence command and warn it actually powers off the node
- Add missing smart-exporter, ras-exporter, hwtemp-exporter to Monitoring section