### PR TITLE
Add cockpit-zfs and cockpit-scheduler plugins to cockpit role

### DIFF
--- a/roles/cockpit/tasks/Debian.yml
+++ b/roles/cockpit/tasks/Debian.yml
@@ -52,5 +52,7 @@
       - cockpit-file-sharing
       - cockpit-identities
       - cockpit-navigator
+      - cockpit-zfs
+      - cockpit-scheduler
     state: present
   ignore_errors: true  # repo may not have packages for your arch/release

--- a/roles/cockpit/tasks/RedHat.yml
+++ b/roles/cockpit/tasks/RedHat.yml
@@ -59,5 +59,7 @@
       - cockpit-file-sharing
       - cockpit-identities
       - cockpit-navigator
+      - cockpit-zfs
+      - cockpit-scheduler
     state: present
   ignore_errors: true  # repo may not have packages for your arch/release

--- a/roles/cockpit/tasks/Ubuntu.yml
+++ b/roles/cockpit/tasks/Ubuntu.yml
@@ -52,5 +52,7 @@
       - cockpit-file-sharing
       - cockpit-identities
       - cockpit-navigator
+      - cockpit-zfs
+      - cockpit-scheduler
     state: present
   ignore_errors: true  # repo may not have packages for every Ubuntu release


### PR DESCRIPTION
Adds the 45Drives cockpit-zfs (ZFS pool/dataset management UI) and cockpit-scheduler (cron task scheduling UI) packages to the existing 45Drives Houston plugin install task across all OS variants.