### PR TITLE
fix: bash script bugs and minor simplifications

### DIFF
--- a/roles/iscsi-initiator/templates/create-pool.sh.j2
+++ b/roles/iscsi-initiator/templates/create-pool.sh.j2
@@ -45,7 +45,7 @@ echo "=== Attempting auto-discovery of iSCSI device paths by LUN number ==="
 REMOTE_DISKS=()
 discovery_ok=true
 
-if ! iscsiadm -m session &>/dev/null 2>&1; then
+if ! iscsiadm -m session &>/dev/null; then
   echo "WARNING: No active iSCSI sessions. Cannot auto-discover remote paths."
   discovery_ok=false
 fi

--- a/roles/monitoring/templates/reboot-required-exporter.sh.j2
+++ b/roles/monitoring/templates/reboot-required-exporter.sh.j2
@@ -17,8 +17,7 @@ fi
 {% elif ansible_os_family == 'RedHat' %}
 # Rocky/RHEL: use needs-restarting to check if a reboot is needed
 if command -v needs-restarting &>/dev/null; then
-    needs-restarting -r &>/dev/null
-    if [ $? -eq 1 ]; then
+    if ! needs-restarting -r &>/dev/null; then
         reboot_needed=1
     fi
 fi

--- a/roles/monitoring/templates/zfs-scrub-exporter.sh.j2
+++ b/roles/monitoring/templates/zfs-scrub-exporter.sh.j2
@@ -11,6 +11,7 @@ TEXTFILE_TMP="${TEXTFILE}.$$"
 
 # Ensure textfile directory exists
 mkdir -p "${TEXTFILE_DIR}"
+trap 'rm -f "${TEXTFILE_TMP}"' EXIT
 
 # Start building metrics
 {
@@ -139,7 +140,7 @@ mkdir -p "${TEXTFILE_DIR}"
 
         # ─── Per-vdev error counts ──────────────────────────────────────
         while IFS= read -r vdev_line; do
-            if echo "${vdev_line}" | grep -qE "^\s+(/dev/disk/by-id/|/dev/sd|/dev/nvme)[^ ]+\s+"; then
+            if echo "${vdev_line}" | grep -qE "^\s+(/dev/disk/by-id/|/dev/disk/by-path/|/dev/sd|/dev/nvme)[^ ]+\s+"; then
                 VDEV=$(echo "${vdev_line}" | awk '{print $1}' | xargs basename)
                 READ_ERR=$(echo "${vdev_line}" | awk '{print $3}')
                 WRITE_ERR=$(echo "${vdev_line}" | awk '{print $4}')

--- a/roles/services/templates/setup-client-iscsi-target.sh.j2
+++ b/roles/services/templates/setup-client-iscsi-target.sh.j2
@@ -137,9 +137,12 @@ fi
 # Apply per-initiator CHAP credentials from encrypted file
 chap_key="{{ tpg_num }}:{{ initiator_iqn }}"
 if [[ "${CHAP_USER[$chap_key]+_}" ]]; then
-  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }}/acls/{{ initiator_iqn }} set auth userid=${CHAP_USER[$chap_key]} password=${CHAP_PASS[$chap_key]}"
+  # Wrap in single quotes; escape embedded single quotes as '\''.
+  _cu="${CHAP_USER[$chap_key]}"
+  _cp="${CHAP_PASS[$chap_key]}"
+  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }}/acls/{{ initiator_iqn }} set auth userid='${_cu//\'/\'\\\'\'}' password='${_cp//\'/\'\\\'\'}'"
   targetcli <<< "$_chap_cmd"
-  unset _chap_cmd
+  unset _chap_cmd _cu _cp
 fi
 {% endif %}
 {% endfor %}
@@ -166,9 +169,12 @@ done < <(targetcli ls /iscsi/"${TARGET_IQN}"/tpg{{ tpg_num }}/acls/ 2>/dev/null 
 {% elif vlan_has_chap %}
 # TPG-level CHAP — all initiators use the same credential (generate_node_acls mode)
 if [[ "${TPG_CHAP_USER[{{ tpg_num }}]+_}" ]]; then
-  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }} set auth userid=${TPG_CHAP_USER[{{ tpg_num }}]} password=${TPG_CHAP_PASS[{{ tpg_num }}]}"
+  # Wrap in single quotes; escape embedded single quotes as '\''.
+  _cu="${TPG_CHAP_USER[{{ tpg_num }}]}"
+  _cp="${TPG_CHAP_PASS[{{ tpg_num }}]}"
+  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }} set auth userid='${_cu//\'/\'\\\'\'}' password='${_cp//\'/\'\\\'\'}'"
   targetcli <<< "$_chap_cmd"
-  unset _chap_cmd
+  unset _chap_cmd _cu _cp
 fi
 {% endif %}
 {% endfor %}

--- a/roles/zfs/templates/zfs-scrub-wrapper.sh.j2
+++ b/roles/zfs/templates/zfs-scrub-wrapper.sh.j2
@@ -19,23 +19,26 @@ fi
 
 log "Pool '${POOL_NAME}' is imported. Proceeding with pre-scrub checks..."
 
+# Capture pool status once and reuse for all checks below
+POOL_STATUS=$(zpool status "${POOL_NAME}" 2>/dev/null || true)
+
 # Check if pool is in a healthy state
 if zpool status -x "${POOL_NAME}" | grep -qv "pool '${POOL_NAME}' is healthy"; then
     log "WARNING: Pool '${POOL_NAME}' is not healthy. Checking status..."
 
     # Check for specific conditions that should block scrub
-    if zpool status "${POOL_NAME}" | grep -q "resilver in progress"; then
+    if echo "${POOL_STATUS}" | grep -q "resilver in progress"; then
         log "ERROR: Resilver in progress. Skipping scrub to avoid performance impact."
         exit 0
     fi
 
-    if zpool status "${POOL_NAME}" | grep -q "scrub in progress"; then
+    if echo "${POOL_STATUS}" | grep -q "scrub in progress"; then
         log "INFO: Scrub already in progress. Nothing to do."
         exit 0
     fi
 
 {% if zfs_scrub_skip_on_degraded | default(true) %}
-    if zpool status "${POOL_NAME}" | grep -qE "(DEGRADED|FAULTED|UNAVAIL)"; then
+    if echo "${POOL_STATUS}" | grep -qE "(DEGRADED|FAULTED|UNAVAIL)"; then
         log "ERROR: Pool is degraded/faulted. Skipping scrub. Manual intervention required."
         exit 1
     fi
@@ -45,7 +48,7 @@ if zpool status -x "${POOL_NAME}" | grep -qv "pool '${POOL_NAME}' is healthy"; t
 fi
 
 # Check if a scrub was recently completed
-LAST_SCRUB=$(zpool status "${POOL_NAME}" | grep "scan:" | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}" | tail -1 || echo "never")
+LAST_SCRUB=$(echo "${POOL_STATUS}" | grep "scan:" | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}" | tail -1 || echo "never")
 if [ "${LAST_SCRUB}" != "never" ]; then
     LAST_SCRUB_EPOCH=$(date -d "${LAST_SCRUB}" +%s)
     NOW_EPOCH=$(date +%s)


### PR DESCRIPTION
Two real bugs fixed:
- setup-client-iscsi-target.sh.j2: CHAP credentials were interpolated bare into targetcli command strings, breaking auth when passwords contain spaces, $, or other shell metacharacters. Apply the same single-quote-escape pattern already used in sync-iscsi-luns.sh.j2 (both per-initiator ACL CHAP and per-TPG generate_node_acls CHAP).
- zfs-scrub-exporter.sh.j2: vdev path regex excluded /dev/disk/by-path/, so read/write/checksum errors on iSCSI mirror halves were never reported. Added the missing prefix.

Minor fixes:
- zfs-scrub-exporter.sh.j2: add EXIT trap to clean up TEXTFILE_TMP so an early exit (empty pool status) doesn't leave a stale .prom.$$ file.
- zfs-scrub-wrapper.sh.j2: capture `zpool status` output once and reuse it for the three in-flight checks (resilver, scrub, degraded), rather than forking three separate subprocesses.
- reboot-required-exporter.sh.j2: replace $?-after-command pattern with direct `if !` on needs-restarting.
- create-pool.sh.j2: remove redundant 2>&1 after &>/dev/null.

https://claude.ai/code/session_013E4YstaWfKFX7fZwvWsX25