### PR TITLE
fix: iSCSI sync script bugs and simplify CHAP/Python logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Ansible playbook for HA ZFS-over-iSCSI SAN (Debian 12, Ubuntu 22.04/24.04, Rocky
 | Firewall template | `roles/hardening/templates/nftables.conf.j2` |
 | STONITH script template | `roles/pacemaker/templates/configure-stonith.sh.j2` |
 | iSCSI LUN sync script (Pacemaker resource) | `roles/services/templates/sync-iscsi-luns.sh.j2` |
+| iSCSI CHAP credential decrypt helper (sourced by setup + sync scripts) | `roles/services/templates/iscsi-chap-decrypt.sh.j2` |
 | iSCSI client config save script (ExecStop, path watcher) | `roles/services/templates/iscsi-save-client-config.py.j2` |
 | iSCSI client config strip script (run each deploy) | `roles/services/templates/iscsi-strip-client-config.py.j2` |
 | iSCSI config sync path/service units | `roles/services/templates/iscsi-config-sync.{path,service}.j2` |
@@ -112,7 +113,7 @@ Each iSCSI-enabled client VLAN gets its own LIO TPG. Per-VLAN fields in `client_
 
 ### iSCSI CHAP Encrypted Credentials
 
-CHAP credentials are never stored in plaintext on disk. Ansible deploys `/root/.iscsi-chap.env.enc` (mode 0600, encrypted with OpenSSL AES-256-CBC using `/etc/machine-id` as passphrase). Both `setup-client-iscsi-target.sh` and `sync-iscsi-luns.sh` decrypt at runtime via `eval "$(openssl enc -d ...)"`.
+CHAP credentials are never stored in plaintext on disk. Ansible deploys `/root/.iscsi-chap.env.enc` (mode 0600, encrypted with OpenSSL AES-256-CBC using `/etc/machine-id` as passphrase). Both `setup-client-iscsi-target.sh` and `sync-iscsi-luns.sh` source `/root/iscsi-chap-decrypt.sh` at runtime, which runs `eval "$(openssl enc -d ...)"` and populates four associative arrays in the caller's scope: `CHAP_USER`/`CHAP_PASS` (keyed `"tpg:iqn"`, per-initiator ACL-mode VLANs) and `TPG_CHAP_USER`/`TPG_CHAP_PASS` (keyed by TPG number, `generate_node_acls` VLANs).
 
 - **Machine-specific**: the encrypted file is useless on any other node
 - **Password rotation**: re-run `ansible-playbook ... --tags services` → new encrypted file deployed → re-run setup script

--- a/roles/services/tasks/main.yml
+++ b/roles/services/tasks/main.yml
@@ -129,6 +129,13 @@
   changed_when: true
   no_log: true
 
+- name: Deploy iSCSI CHAP decryption helper
+  ansible.builtin.template:
+    src: iscsi-chap-decrypt.sh.j2
+    dest: /root/iscsi-chap-decrypt.sh
+    mode: "0700"
+  when: client_vlans | selectattr('services', 'contains', 'iscsi') | list | length > 0
+
 - name: Generate client iSCSI target setup script
   ansible.builtin.template:
     src: setup-client-iscsi-target.sh.j2

--- a/roles/services/templates/iscsi-chap-decrypt.sh.j2
+++ b/roles/services/templates/iscsi-chap-decrypt.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Managed by Ansible — Decrypt iSCSI CHAP credentials from encrypted env file
+# Source this script (do not execute directly): . /root/iscsi-chap-decrypt.sh
+#
+# Populates four associative arrays in the calling script's scope:
+#   CHAP_USER["tpg:iqn"]    / CHAP_PASS["tpg:iqn"]    — per-initiator (ACL-mode VLANs)
+#   TPG_CHAP_USER["tpg"]    / TPG_CHAP_PASS["tpg"]    — per-TPG (generate_node_acls VLANs)
+declare -A CHAP_USER CHAP_PASS TPG_CHAP_USER TPG_CHAP_PASS
+if [ -f /root/.iscsi-chap.env.enc ]; then
+  eval "$(openssl enc -d -aes-256-cbc -pbkdf2 -pass file:/etc/machine-id \
+    -in /root/.iscsi-chap.env.enc 2>/dev/null)" || {
+    echo "WARNING: Failed to decrypt CHAP credentials — CHAP will not be applied"
+  }
+fi

--- a/roles/services/templates/setup-client-iscsi-target.sh.j2
+++ b/roles/services/templates/setup-client-iscsi-target.sh.j2
@@ -37,15 +37,8 @@ echo "=== Configuring client iSCSI target: ${TARGET_IQN} ==="
 echo "    iSCSI VLANs: {{ iscsi_vlans | map(attribute='name') | join(', ') }} (${TOTAL_TPGS} TPG(s))"
 
 # ─── Decrypt CHAP credentials ─────────────────────────────────────────────
-# CHAP_USER["tpg:iqn"] / CHAP_PASS["tpg:iqn"] — per-initiator (ACL-mode VLANs)
-# TPG_CHAP_USER["tpg"] / TPG_CHAP_PASS["tpg"] — per-TPG (generate_node_acls VLANs)
-declare -A CHAP_USER CHAP_PASS TPG_CHAP_USER TPG_CHAP_PASS
-if [ -f /root/.iscsi-chap.env.enc ]; then
-  eval "$(openssl enc -d -aes-256-cbc -pbkdf2 -pass file:/etc/machine-id \
-    -in /root/.iscsi-chap.env.enc 2>/dev/null)" || {
-    echo "WARNING: Failed to decrypt CHAP credentials — CHAP will not be applied"
-  }
-fi
+# Populates CHAP_USER/CHAP_PASS (per-initiator) and TPG_CHAP_USER/TPG_CHAP_PASS (per-TPG)
+. /root/iscsi-chap-decrypt.sh
 
 # ─── Create target if needed (tpg1 auto-created with target) ──────────────────
 if targetcli ls /iscsi/"${TARGET_IQN}" &>/dev/null; then
@@ -137,9 +130,11 @@ fi
 # Apply per-initiator CHAP credentials from encrypted file
 chap_key="{{ tpg_num }}:{{ initiator_iqn }}"
 if [[ "${CHAP_USER[$chap_key]+_}" ]]; then
-  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }}/acls/{{ initiator_iqn }} set auth userid=${CHAP_USER[$chap_key]} password=${CHAP_PASS[$chap_key]}"
+  _cu="${CHAP_USER[$chap_key]}"
+  _cp="${CHAP_PASS[$chap_key]}"
+  _chap_cmd="/iscsi/${TARGET_IQN}/tpg{{ tpg_num }}/acls/{{ initiator_iqn }} set auth userid='${_cu//\'/\'\\\'\'}' password='${_cp//\'/\'\\\'\'}'"
   targetcli <<< "$_chap_cmd"
-  unset _chap_cmd
+  unset _chap_cmd _cu _cp
 fi
 {% endif %}
 {% endfor %}
@@ -186,46 +181,6 @@ for tpg_tag in $(targetcli ls /iscsi/"${TARGET_IQN}"/ 2>/dev/null \
     echo "    Then remove ACLs, portals, and LUNs before deleting the TPG."
   fi
 done
-
-# ─── Write per-VLAN ACL files to shared storage ────────────────────────────────
-# sync-iscsi-luns.sh reads acls-<vlan>.conf after pool import to recreate ACLs
-# on whichever node becomes active. Edit these files directly to add/remove
-# initiators without re-running Ansible.
-ACLS_DIR="/{{ zfs_pool_name }}/cluster-config/iscsi"
-mkdir -p "${ACLS_DIR}"
-{% for cv in iscsi_vlans %}
-{% if not (cv.generate_node_acls | default(false)) %}
-{% set vlan_acls = cv.iscsi_acls if cv.iscsi_acls is defined else iscsi_client_acls %}
-cat > "${ACLS_DIR}/acls-{{ cv.name }}.conf" <<'ACLS_{{ cv.name | upper }}_EOF'
-# Managed by Ansible — iSCSI initiator ACLs for VLAN: {{ cv.name }} (TPG{{ loop.index }})
-# One IQN per line. Edit to add/remove initiators.
-# Changes apply on next failover or: bash /root/sync-iscsi-luns.sh
-{% for entry in vlan_acls %}
-{% set initiator_iqn = entry.iqn if entry is mapping else entry %}
-{{ initiator_iqn }}
-{% endfor %}
-ACLS_{{ cv.name | upper }}_EOF
-chmod 0640 "${ACLS_DIR}/acls-{{ cv.name }}.conf"
-echo "ACL list seeded at ${ACLS_DIR}/acls-{{ cv.name }}.conf"
-{% endif %}
-{% endfor %}
-
-# Write legacy union acls.conf for backward compatibility (all VLANs combined)
-cat > "${ACLS_DIR}/acls.conf" <<'UNION_ACLS_EOF'
-# Managed by Ansible — union ACL list (all iSCSI VLANs combined)
-# Per-VLAN files: acls-<vlan-name>.conf (preferred for per-VLAN sync)
-{% for cv in iscsi_vlans %}
-{% if not (cv.generate_node_acls | default(false)) %}
-{% set vlan_acls = cv.iscsi_acls if cv.iscsi_acls is defined else iscsi_client_acls %}
-# VLAN: {{ cv.name }} (TPG{{ loop.index }})
-{% for entry in vlan_acls %}
-{% set initiator_iqn = entry.iqn if entry is mapping else entry %}
-{{ initiator_iqn }}
-{% endfor %}
-{% endif %}
-{% endfor %}
-UNION_ACLS_EOF
-chmod 0640 "${ACLS_DIR}/acls.conf"
 
 targetcli saveconfig
 echo ""

--- a/roles/services/templates/sync-iscsi-luns.sh.j2
+++ b/roles/services/templates/sync-iscsi-luns.sh.j2
@@ -9,8 +9,11 @@
 # Phases:
 #   0    — TPG-to-VLAN mapping (baked in at Ansible deploy time)
 #   0.5  — Decrypt CHAP credentials
-#   1    — Restore from shared client-saveconfig.json (merge with local backend)
+#   1    — Merge local backend config with shared client config; extract current
+#           backstore/LUN state for gap-fill (single Python pass)
+#   1.5  — Restore merged config via targetcli
 #   2    — Gap-fill: map any zvols not yet in restored config (crash window safety)
+#   2.5  — Reapply per-TPG CHAP for generate_node_acls VLANs; save if changed
 #   3    — Save updated config to shared storage
 #
 # Usage: bash /root/sync-iscsi-luns.sh
@@ -20,7 +23,6 @@ set -euo pipefail
 
 TARGET_IQN="{{ iscsi_client_iqn }}"
 SHARED_CLIENT_CONFIG="/{{ zfs_pool_name }}/cluster-config/iscsi/client-saveconfig.json"
-TOTAL_TPGS={{ iscsi_vlan_count }}
 
 # ─── Phase 0: TPG-to-VLAN mapping (baked in at Ansible deploy time) ───────────
 declare -A TPG_DATASET TPG_VLAN TPG_BS_PREFIX TPG_GEN_ACLS
@@ -32,24 +34,21 @@ TPG_GEN_ACLS[{{ loop.index }}]="{{ 'true' if (cv.generate_node_acls | default(fa
 {% endfor %}
 
 # ─── Phase 0.5: Decrypt CHAP credentials ──────────────────────────────────────
-# CHAP_USER["tpg:iqn"] / CHAP_PASS["tpg:iqn"] — per-initiator (ACL-mode VLANs)
-# TPG_CHAP_USER["tpg"] / TPG_CHAP_PASS["tpg"] — per-TPG (generate_node_acls VLANs)
-declare -A CHAP_USER CHAP_PASS TPG_CHAP_USER TPG_CHAP_PASS
-if [ -f /root/.iscsi-chap.env.enc ]; then
-  eval "$(openssl enc -d -aes-256-cbc -pbkdf2 -pass file:/etc/machine-id \
-    -in /root/.iscsi-chap.env.enc 2>/dev/null)" || {
-    echo "WARNING: Failed to decrypt CHAP credentials — CHAP will not be applied"
-  }
-fi
+# Populates CHAP_USER/CHAP_PASS (per-initiator) and TPG_CHAP_USER/TPG_CHAP_PASS (per-TPG)
+. /root/iscsi-chap-decrypt.sh
 
 echo "=== Syncing iSCSI LUNs for target: ${TARGET_IQN} ==="
 {% for cv in iscsi_vlans %}
 echo "    TPG{{ loop.index }}: VLAN={{ cv.name }}, dataset={{ cv.iscsi_dataset | default(iscsi_client_zvol_dataset) }}"
 {% endfor %}
 
-# ─── Phase 1: Restore from shared storage ─────────────────────────────────────
+# ─── Phase 1: Merge configs and extract current state (single Python pass) ────
+# Merges local backend config (disk backstores + non-client targets) with the
+# shared client config (zvol backstores + client target), writes the result to
+# MERGED_CONFIG, and emits BS|name| / LUN|tpg|index| records to PARSED_STATE
+# for gap-fill — all in one pass to avoid re-reading the merged file.
 echo ""
-echo "--- Phase 1: Restore from shared client config ---"
+echo "--- Phase 1: Merge and parse config ---"
 
 if [ ! -f "${SHARED_CLIENT_CONFIG}" ]; then
     echo "ERROR: ${SHARED_CLIENT_CONFIG} not found."
@@ -57,15 +56,12 @@ if [ ! -f "${SHARED_CLIENT_CONFIG}" ]; then
     exit 1
 fi
 
-# Merge: local backend config (disk backstores + non-client targets) with
-# client config (zvol backstores + client target). Written to a temp file for
-# targetcli restoreconfig. This is safe: during failover the peer is either
-# fenced or has stopped the pool — no active backend sessions exist.
 MERGED_CONFIG=$(mktemp /tmp/lio-merged-XXXXXX.json)
-trap 'rm -f "${MERGED_CONFIG}"' EXIT
+PARSED_STATE=$(mktemp /tmp/lio-parsed-XXXXXX.txt)
+trap 'rm -f "${MERGED_CONFIG}" "${PARSED_STATE}"' EXIT
 
-python3 - << PYEOF
-import json
+python3 - > "${PARSED_STATE}" << PYEOF
+import json, sys
 
 LOCAL_CONFIG  = "{{ _iscsi_saveconfig_path }}"
 CLIENT_CONFIG = "${SHARED_CLIENT_CONFIG}"
@@ -112,9 +108,26 @@ with open(OUTPUT, "w") as f:
 bs_count  = len(client_storage)
 tpg_count = sum(len(t.get("tpgs", [])) for t in client_targets)
 print(f"  Merged: {len(backend_storage)} backend + {bs_count} client backstores, "
-      f"{len(client_targets)} client target(s), {tpg_count} TPG(s)")
+      f"{len(client_targets)} client target(s), {tpg_count} TPG(s)", file=sys.stderr)
+
+# Emit BS and LUN records for gap-fill phase (stdout → PARSED_STATE)
+for bs in merged.get("storage_objects", []):
+    if bs.get("plugin") == "block" and bs.get("dev", "").startswith("/dev/zvol/"):
+        name = bs.get("name", "")
+        if name:
+            print(f"BS|{name}|")
+
+for t in merged.get("targets", []):
+    if t.get("wwn") == CLIENT_IQN:
+        for tpg in t.get("tpgs", []):
+            tpg_tag = tpg.get("tag", 0)
+            for lun in tpg.get("luns", []):
+                lun_index = lun.get("index", 0)
+                print(f"LUN|{tpg_tag}|{lun_index}")
+        break
 PYEOF
 
+# ─── Phase 1.5: Restore merged config ─────────────────────────────────────────
 echo "  Restoring merged config via targetcli..."
 targetcli restoreconfig "${MERGED_CONFIG}"
 echo "  Config restored."
@@ -142,39 +155,9 @@ while IFS='|' read -r _type _key _val; do
             fi
             ;;
     esac
-done < <(ISCSI_TARGET="${TARGET_IQN}" MERGED_CFG="${MERGED_CONFIG}" python3 - << 'PYEOF'
-import json, sys, os
+done < "${PARSED_STATE}"
 
-# Read from the MERGED config that was just restored — NOT from saveconfig.json,
-# which is stripped (backend-only) and would cause all client backstores to appear
-# missing, leading to duplicate LUN mappings.
-merged_cfg = os.environ.get("MERGED_CFG", "")
-target_iqn = os.environ.get("ISCSI_TARGET", "")
-
-if not merged_cfg or not os.path.exists(merged_cfg):
-    sys.exit(0)
-
-with open(merged_cfg) as f:
-    config = json.load(f)
-
-for bs in config.get("storage_objects", []):
-    if bs.get("plugin") == "block" and bs.get("dev", "").startswith("/dev/zvol/"):
-        name = bs.get("name", "")
-        if name:
-            print(f"BS|{name}|")
-
-for t in config.get("targets", []):
-    if t.get("wwn") == target_iqn:
-        for tpg in t.get("tpgs", []):
-            tpg_tag = tpg.get("tag", 0)
-            for lun in tpg.get("luns", []):
-                lun_index = lun.get("index", 0)
-                print(f"LUN|{tpg_tag}|{lun_index}")
-        break
-PYEOF
-)
-
-for tpg_tag in $(seq 1 "$TOTAL_TPGS"); do
+for tpg_tag in $(seq 1 "${#TPG_DATASET[@]}"); do
     vlan_name="${TPG_VLAN[$tpg_tag]}"
     dataset="${TPG_DATASET[$tpg_tag]}"
     bs_prefix="${TPG_BS_PREFIX[$tpg_tag]}"
@@ -214,12 +197,15 @@ else
 fi
 
 # ─── Phase 2.5: Reapply per-TPG CHAP for generate_node_acls VLANs ────────────
-# The restore brings back CHAP settings from the saved config, but we reapply
-# here to ensure credentials are current after rotation (re-deploy --tags services).
+# Reapplied from the freshly-decrypted env file each run so that credential
+# rotations take effect immediately without needing a saveconfig → shared storage
+# round-trip. A saveconfig is called when CHAP is applied so that Phase 3 writes
+# the current credentials (not stale ones from the restored config) to shared
+# storage.
 echo ""
 echo "--- Phase 2.5: Per-TPG CHAP (generate_node_acls VLANs) ---"
 chap_applied=false
-for tpg_tag in $(seq 1 "$TOTAL_TPGS"); do
+for tpg_tag in $(seq 1 "${#TPG_DATASET[@]}"); do
     if [ "${TPG_GEN_ACLS[$tpg_tag]}" = "true" ] && [[ "${TPG_CHAP_USER[$tpg_tag]+_}" ]]; then
         echo "  + Setting TPG-level CHAP and authentication=1 for tpg${tpg_tag}"
         targetcli <<< "/iscsi/${TARGET_IQN}/tpg${tpg_tag} set attribute authentication=1"
@@ -236,6 +222,11 @@ for tpg_tag in $(seq 1 "$TOTAL_TPGS"); do
 done
 if [ "$chap_applied" = "false" ]; then
     echo "  (no per-TPG CHAP configured)"
+else
+    # Persist CHAP updates to saveconfig.json so Phase 3 writes current
+    # credentials to shared storage (not the stale values from the restored config).
+    targetcli saveconfig
+    echo "  Per-TPG CHAP saved to LIO config."
 fi
 
 # ─── Phase 3: Save updated config to shared storage ───────────────────────────


### PR DESCRIPTION
Fixes four issues identified in code review:

1. Unquoted per-initiator CHAP credentials in setup-client-iscsi-target.sh — passwords with spaces or shell metacharacters would silently fail. Apply the same single-quote escaping already used in sync Phase 2.5.

2. Phase 2.5 CHAP updates not persisted to shared storage in sync script — generate_node_acls CHAP credentials were applied to live LIO but saveconfig was never called, so Phase 3 would write stale credentials from the restored config to shared storage. Add targetcli saveconfig after Phase 2.5 when CHAP was applied.

3. Dead ACL .conf file generation in setup script removed — the per-VLAN acls-<vlan>.conf and union acls.conf files were written to shared storage but never read by sync-iscsi-luns.sh. The sync relies entirely on client-saveconfig.json (restored in Phase 1). The comment claiming sync reads these files was also incorrect.

4. Duplicate CHAP decryption boilerplate extracted to shared iscsi-chap-decrypt.sh (sourced by both scripts).

Also merges the two sequential Python invocations in sync-iscsi-luns.sh (Phase 1 merge + Phase 2 state extraction) into a single pass: Python now writes MERGED_CONFIG and emits BS|/LUN| records to a temp file in one step, avoiding a second parse of the same JSON. TOTAL_TPGS variable removed in favour of ${#TPG_DATASET[@]}.

https://claude.ai/code/session_01HWHxvsGjFnNPjNv4Lisz8a